### PR TITLE
Migra do HoneyBadger para o Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'gabba', '1.0.1'
 gem 'rest-client', '2.1.0'
 gem 'puma', '4.3.5'
 gem 'google-api-client', '0.7.1', require: 'google/api_client'
-gem 'honeybadger', '4.5.1'
+gem 'sentry-raven', '2.13.0'
 gem 'lograge', '0.11.2'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,6 @@ GEM
       signet (>= 0.5.0)
       uuidtools (>= 2.1.0)
     hashdiff (1.0.1)
-    honeybadger (4.5.1)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -161,6 +160,8 @@ GEM
     rgeo-activerecord (4.0.5)
       activerecord (~> 4.2)
       rgeo (~> 0.3)
+    sentry-raven (2.13.0)
+      faraday (>= 0.7.6, < 1.0)
     signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -194,7 +195,6 @@ DEPENDENCIES
   dotenv-rails (= 2.7.5)
   gabba (= 1.0.1)
   google-api-client (= 0.7.1)
-  honeybadger (= 4.5.1)
   lograge (= 0.11.2)
   pg (= 0.21.0)
   pry (= 0.12.2)
@@ -202,6 +202,7 @@ DEPENDENCIES
   rails (= 4.2.11.1)
   rails_12factor (= 0.0.3)
   rest-client (= 2.1.0)
+  sentry-raven (= 2.13.0)
   webmock (= 3.9.1)
 
 RUBY VERSION

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "raven"
+
+Raven.configure do |config|
+  config.dsn = ENV["SENTRY_DSN"]
+  config.release = ENV["APP_REVISION"] || "dev"
+  config.environments = %w[development staging production]
+  config.current_environment = ENV["SENTRY_ENV"] || "development"
+end


### PR DESCRIPTION
<!--- Crie um título explicativo para o seu PR -->
https://trello.com/c/9VvjE2GU/11965-migrar-apps-para-do-honeybadger-para-o-sentry-ga-integration
Depende de: https://github.com/vnda/ga-integration/pull/55
**NOTA**: vai precisar fazer rebase para o master depois do merge do PR 55

## Descrição
Remove do `Gemfile` o HoneyBadger e coloca a gem `sentry-raven`.

## Motivação e contexto
Estamos começando a deixar de usar o HoneyBadger para centralizar todas as mensagens de erro no Sentry.
Neste projeto, não havia nenhuma chamada do HoneyBadger, então a migração limitou-se à instalação da gem para uso posterior e à adição do arquivo de configuração da mesma.
Sobre o uso da gem `sentry-raven` ao invés das mais recentes `sentry-ruby` e `sentry-rails`, isso se deve pois as gems mais recentes entram em conflito com a versão do Faraday utilizada pela gem `google-api-client`, e as versões mais recentes desta última reportam erro nos testes.

## Como as modificações foram testadas?
Os testes foram feitos via rspec

## Categoria das modificações
<!--- Que tipo de modificação seu código introduz? Coloque um `x` em todos os boxes que se aplicam -->
- [ ] Bug fix (mudança que apenas corrige um bug e não quebra compatibilidade)
- [ ] Nova feature (mudança que adiciona funcionalidade e não quebra compatibilidade)
- [x] Breaking change (fix ou feature que faz com que a funcionalidade existente se comporte diferente do esperado)

## Checklist:
<!--- Coloque um `x` em todos os boxes que se aplicam -->
<!--- Se você não tem certeza sobre qualquer um dos pontos abaixo, não hesite em perguntar -->
- [x] Meu código segue o style guide do projeto
- [ ] Minha modificação requer mudanças na documentação
- [ ] Eu atualizei a documentação necessária
